### PR TITLE
Fix waiting before retry

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -60,7 +60,7 @@ function retryRequest (resilient, servers, options, cb) {
 
 function waitBeforeRetry (retrier, options) {
   return function () {
-    _.delay(retrier, options.retryWait)
+    _.delay(retrier, options.waitBeforeRetry)
   }
 }
 


### PR DESCRIPTION
options.waitBeforeRetry should be used instead of options.retryWait.
waitBeforeRetry is a documented config option, which is used in default.js as well. Now, obviously, delay doesn't work since retryWait is undefined.