### PR TITLE
Fix options usage

### DIFF
--- a/lib/servers.js
+++ b/lib/servers.js
@@ -50,6 +50,8 @@ Servers.prototype.resetStats = function () {
 }
 
 Servers.prototype.sort = function (operation, options) {
+  if (options)
+    options = options.get();
   var servers = this.servers.slice(0)
   if (servers.length > 1) {
     servers.sort(function (x, y) {


### PR DESCRIPTION
Now options are passed as Options object (with 'store' in it), but used as a simple object (see roundRobinSort, which can't find options.roundRobinSize, and roundRobin logic is never applied). This fix converts Options-typed object o a simple object.