### PR TITLE
Catch unhandled exceptions during content parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.3.2
+VERSION = 0.3.3
 BROWSERIFY = node ./node_modules/.bin/browserify
 MOCHA = ./node_modules/.bin/mocha
 LINTER = ./node_modules/.bin/standard

--- a/lib/http.js
+++ b/lib/http.js
@@ -20,7 +20,7 @@ function mapResponse (cb) {
     }
     if (body) {
       try {
-        (err || res).data = isJSONContent (err || res) ? JSON.parse (body) : body
+        (err || res).data = isJSONContent(err || res) ? JSON.parse(body) : body
       } catch (e) {
         err = e
       }

--- a/lib/http.js
+++ b/lib/http.js
@@ -19,7 +19,11 @@ function mapResponse (cb) {
       res.status = res.statusCode
     }
     if (body) {
-      (err || res).data = isJSONContent(err || res) ? JSON.parse(body) : body
+      try {
+        (err || res).data = isJSONContent (err || res) ? JSON.parse (body) : body
+      } catch (e) {
+        err = e
+      }
     }
     cb(err, res)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var Resilient = require('./resilient')
 
 module.exports = Resilient
 
-Resilient.VERSION = '0.3.2'
+Resilient.VERSION = '0.3.3'
 Resilient.CLIENT_VERSION = http.VERSION
 Resilient.defaults = defaults
 Resilient.Options = Options

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resilient",
   "description": "Fault tolerant, reactive, middleware-oriented and full featured HTTP client for node.js and browsers",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "repository": "resilient-http/resilient.js",
   "author": "Tomas Aparicio",

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -312,7 +312,7 @@ describe('Discovery', function () {
       discovery: {
         retry: 3,
         waitBeforeRetry: 50,
-		timeout: 100,
+        timeout: 100,
         servers: [
           'http://127.0.0.1:8198',
           'http://127.0.0.1:8199',

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -312,6 +312,7 @@ describe('Discovery', function () {
       discovery: {
         retry: 3,
         waitBeforeRetry: 50,
+		timeout: 100,
         servers: [
           'http://127.0.0.1:8198',
           'http://127.0.0.1:8199',

--- a/test/http.js
+++ b/test/http.js
@@ -139,6 +139,8 @@ describe('HTTP', function () {
       nock('http://server')
         .post('/hello', '{"ping":"pong"}')
         .reply(202, { hello: 'world' })
+        .get('/bad-json')
+        .reply(200, '{"a":5', {'Content-Type': 'application/json'})
     })
 
     it('should perform a valid request', function (done) {
@@ -150,6 +152,18 @@ describe('HTTP', function () {
         expect(err).to.be.null
         expect(res.status).to.be.equal(202)
         expect(res.data).to.be.deep.equal({ hello: 'world' })
+        done()
+      })
+    })
+
+    it('should handle unparsable response', function (done) {
+      http({
+        url: 'http://server/bad-json',
+        method: 'GET'
+      }, function (err, res) {
+        expect(err).to.be.notNull
+        expect(res.status).to.be.equal(200)
+        expect(res.data).to.be.undefined
         done()
       })
     })


### PR DESCRIPTION
If response content cannot be parsed, an error should be passed to the callback rather than throwing one.

Also created a separate test case to demonstrate the fix.